### PR TITLE
Fix IDs when creating IconDirectoryResource from an .ico file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-### 1.7
+### 1.7 (Next)
 
 **Bugs**
 
-* [#48](https://github.com/resourcelib/resourcelib/pull/56) Fixed IconDirectoryResource.SaveTo has bugs with some .ico file
+* [#48](https://github.com/resourcelib/resourcelib/pull/56): Fixed `IconDirectoryResource.SaveTo` has bugs with some .ico file - [@jairbubbles](https://github.com/jairbubbles).
 
 ### 1.6 (4/22/2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bugs**
 
-* [#48](https://github.com/resourcelib/resourcelib/pull/56): Fixed `IconDirectoryResource.SaveTo` has bugs with some .ico file - [@jairbubbles](https://github.com/jairbubbles).
+* [#48](https://github.com/resourcelib/resourcelib/issues/48): Fixed `IconDirectoryResource.SaveTo` has bugs with some .ico file - [@jairbubbles](https://github.com/jairbubbles).
 
 ### 1.6 (4/22/2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.7
+
+**Bugs**
+
+* [#48](https://github.com/resourcelib/resourcelib/pull/56) Fixed IconDirectoryResource.SaveTo has bugs with some .ico file
+
 ### 1.6 (4/22/2017)
 
 **New Features**

--- a/Source/ResourceLib/IconDirectoryResource.cs
+++ b/Source/ResourceLib/IconDirectoryResource.cs
@@ -42,10 +42,9 @@ namespace Vestris.ResourceLib
         public IconDirectoryResource(IconFile iconFile)
             : base(Kernel32.ResourceTypes.RT_GROUP_ICON)
         {            
-            for (UInt16 id = 0; id < iconFile.Icons.Count; id++)
+            for (var id = 0; id < iconFile.Icons.Count; id++)
             {
-                IconResource iconResource = new IconResource(
-                    iconFile.Icons[id], new ResourceId(id), _language);
+                IconResource iconResource = new IconResource(iconFile.Icons[id], new ResourceId((uint)id + 1), _language);
                 Icons.Add(iconResource);
             }
         }

--- a/Source/ResourceLibUnitTests/IconResourceTests.cs
+++ b/Source/ResourceLibUnitTests/IconResourceTests.cs
@@ -12,6 +12,16 @@ namespace Vestris.ResourceLibUnitTests
     [TestFixture]
     public class IconResourceTests
     {
+        private static void CheckIconIds(IconDirectoryResource iconDirectoryResource)
+        {
+            Assert.IsTrue(iconDirectoryResource.Icons.Count > 0);
+            for (var i = 0; i < iconDirectoryResource.Icons.Count; i++)
+            {
+                var icon = iconDirectoryResource.Icons[i];
+                Assert.AreEqual(i + 1, icon.Id);
+            }
+        }
+
         [Test]
         public void TestLoadIconResources()
         {
@@ -19,6 +29,7 @@ namespace Vestris.ResourceLibUnitTests
             Assert.IsTrue(File.Exists(filename));
             IconDirectoryResource iconDirectoryResource = new IconDirectoryResource();
             iconDirectoryResource.LoadFrom(filename);
+            CheckIconIds(iconDirectoryResource);
             DumpResource.Dump(iconDirectoryResource);
         }
 
@@ -40,6 +51,7 @@ namespace Vestris.ResourceLibUnitTests
             IconDirectoryResource iconDirectoryResource = new IconDirectoryResource(iconFile);
             DumpResource.Dump(iconDirectoryResource);
             Assert.AreEqual(iconFile.Icons.Count, iconDirectoryResource.Icons.Count);
+            CheckIconIds(iconDirectoryResource);
 
             string filename = HttpUtility.UrlDecode(uri.AbsolutePath);
             Assert.IsTrue(File.Exists(filename));
@@ -51,6 +63,7 @@ namespace Vestris.ResourceLibUnitTests
             Console.WriteLine("Written IconDirectoryResource:");
             IconDirectoryResource newIconDirectoryResource = new IconDirectoryResource();
             newIconDirectoryResource.LoadFrom(targetFilename);
+            CheckIconIds(newIconDirectoryResource);
             DumpResource.Dump(newIconDirectoryResource);
         }
 
@@ -73,6 +86,7 @@ namespace Vestris.ResourceLibUnitTests
             iconDirectoryResource.Language = ResourceUtil.USENGLISHLANGID;
             DumpResource.Dump(iconDirectoryResource);
             Assert.AreEqual(iconFile.Icons.Count, iconDirectoryResource.Icons.Count);
+            CheckIconIds(iconDirectoryResource);
 
             string filename = Path.Combine(Environment.SystemDirectory, "write.exe");
             Assert.IsTrue(File.Exists(filename));
@@ -84,6 +98,7 @@ namespace Vestris.ResourceLibUnitTests
             Console.WriteLine("Written IconDirectoryResource:");
             IconDirectoryResource newIconDirectoryResource = new IconDirectoryResource();
             newIconDirectoryResource.LoadFrom(targetFilename);
+            CheckIconIds(newIconDirectoryResource);
             DumpResource.Dump(newIconDirectoryResource);
         }
     }


### PR DESCRIPTION
Note: I had to tweak the solution to make it compile with VS2017. 

Fixes #48 