### PR TITLE
Improve support for .net assemblies

### DIFF
--- a/Source/ResourceLib/StringTableEntry.cs
+++ b/Source/ResourceLib/StringTableEntry.cs
@@ -23,6 +23,12 @@ namespace Vestris.ResourceLib
         private string _value;
 
         /// <summary>
+        /// When set to true the length in the header will also contain the padding bytes when writing to a stream.
+        /// The MSDN reference (http://www.webcitation.org/6zBLYbvww) does not clarify which variant is 'right'.
+        /// </summary>
+        public static bool ConsiderPaddingForLength = false;
+
+        /// <summary>
         /// String resource header.
         /// </summary>
         public Kernel32.RESOURCE_HEADER Header
@@ -153,6 +159,10 @@ namespace Vestris.ResourceLib
             }
             // wValueLength
             ResourceUtil.WriteAt(w, (w.BaseStream.Position - valuePos) / Marshal.SystemDefaultCharSize, headerPos + 2);
+
+            if (ConsiderPaddingForLength)
+                ResourceUtil.PadToDWORD(w);
+
             // wLength
             ResourceUtil.WriteAt(w, w.BaseStream.Position - headerPos, headerPos);
         }

--- a/Source/ResourceLib/StringTableEntry.cs
+++ b/Source/ResourceLib/StringTableEntry.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Vestris.ResourceLib
 {
@@ -126,9 +125,12 @@ namespace Vestris.ResourceLib
             _key = Marshal.PtrToStringUni(pKey);
 
             IntPtr pValue = ResourceUtil.Align(pKey.ToInt64() + (_key.Length + 1) * Marshal.SystemDefaultCharSize);
-            _value = ((_header.wValueLength > 0)
-                ? Marshal.PtrToStringUni(pValue, _header.wValueLength)
-                : null);
+            if (_header.wValueLength > 0)
+            {
+                _value = Marshal.PtrToStringUni(pValue, _header.wValueLength);
+                if (_value.Length == 0 || _value[_value.Length - 1] != '\0')
+                    _value += '\0';
+            }
         }
 
         /// <summary>

--- a/Source/ResourceLibUnitTests/ResourceTests.cs
+++ b/Source/ResourceLibUnitTests/ResourceTests.cs
@@ -45,10 +45,10 @@ namespace Vestris.ResourceLibUnitTests
         public void TestReadWriteResourceBytes(string path)
         {
             var filename = Path.GetFileName(path);
-            var isDotNet = filename.StartsWith("ClassLibrary_NET");
+            var isDotNet = filename.StartsWith("ClassLibrary_NET") || filename == "idea64.exe";
             if (filename == "idea64.exe")
             {
-                Assert.Ignore("idea64.exe still fails.");
+                Assert.Ignore("idea64.exe doesn't consider null byte for StringTableEntry length");
             }
 
             using (ResourceInfo ri = new ResourceInfo())

--- a/Source/ResourceLibUnitTests/ResourceTests.cs
+++ b/Source/ResourceLibUnitTests/ResourceTests.cs
@@ -40,13 +40,15 @@ namespace Vestris.ResourceLibUnitTests
             }
         }
 
-        [TestCaseSource("TestFiles")]
+        [NonParallelizable]
+        [TestCaseSource("TestFiles")]        
         public void TestReadWriteResourceBytes(string path)
         {
             var filename = Path.GetFileName(path);
-            if (filename.StartsWith("ClassLibrary_NET") || filename == "idea64.exe")
+            var isDotNet = filename.StartsWith("ClassLibrary_NET");
+            if (filename == "idea64.exe")
             {
-                Assert.Ignore(".NET assemblies fail because they consider padding for length in a StringTableEntry");
+                Assert.Ignore("idea64.exe still fails.");
             }
 
             using (ResourceInfo ri = new ResourceInfo())
@@ -55,10 +57,18 @@ namespace Vestris.ResourceLibUnitTests
                 foreach (Resource rc in ri)
                 {
                     Console.WriteLine("Resource: {0} - {1}", rc.TypeName, rc.Name);
-                    GenericResource genericResource = new GenericResource(rc.Type, rc.Name, rc.Language);
+                    GenericResource genericResource = new GenericResource(rc.Type, rc.Name, rc.Language);                    
                     genericResource.LoadFrom(path);
-                    byte[] data = rc.WriteAndGetBytes();
-                    ByteUtils.CompareBytes(genericResource.Data, data);
+                    try
+                    {
+                        StringTableEntry.ConsiderPaddingForLength = isDotNet;
+                        byte[] data = rc.WriteAndGetBytes();                        
+                        ByteUtils.CompareBytes(genericResource.Data, data);
+                    }
+                    finally
+                    {
+                        StringTableEntry.ConsiderPaddingForLength = false;
+                    }                    
                 }
             }
         }


### PR DESCRIPTION
NET assemblies consider padding for length in a _StringTableEntry_. That's the reason why _TestReadWriteResourceBytes_ ignores these file. The only difference is to pad the string before calculating the header size.

I added a static flag to enable this behavior. However it is quit

I first thought about differnet ways to implement this:

* Add 2nd parameter to _SaveTo_ and _Write_ methods
* Use some kind of _WrapperMetaStream_ that holds the information
* Automatically switch the mode depending on the type of assembly being saved to

All of them seemed to be an overkill for this as it is not a must-have feature. The drawback of course is, that it's no longer thread safe to process multiple files and changing the flag in between.

All of the .net (except **idea64.exe**) can now be written binary equal to a stream. The **idea64.exe** has an additional issue:

It in a _StringTableEntry_ the trailing null terminator is not considered for the header value length. So when writing the entries to an ouput stream the result could be shorter than the original. I updated the constructor to always append the null character. Now the output stream has the same length, but not binary equal. 