### PR TITLE
updated System.Drawing.Common to final 4.5.0

### DIFF
--- a/Source/ResourceLib/ResourceLib.csproj
+++ b/Source/ResourceLib/ResourceLib.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Drawing.Common">
-      <Version>4.5.0-preview1-25914-04</Version>
+      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
Microsoft finally released 4.5.0 of [System.Drawing.Common](https://www.nuget.org/packages/System.Drawing.Common/4.5.0).

This fixes #63, the last open issue for [milestone 2.0](https://github.com/resourcelib/resourcelib/milestone/2).