### PR TITLE
Fixed incompletely update Icon language id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### 2.2 (Next)
 
-* Your contribution here.
+**Bugs**
+
+* [#79](https://github.com/resourcelib/resourcelib/pull/79): Setting `Language` on an `IconDirectoryResource` did not update the language of contained icons - [@xiangsxuan](https://github.com/xiangsxuan).
 
 ### 2.1 (2/12/2019)
 

--- a/Source/ResourceLib/IconDirectoryResource.cs
+++ b/Source/ResourceLib/IconDirectoryResource.cs
@@ -13,6 +13,22 @@ namespace Vestris.ResourceLib
     public class IconDirectoryResource : DirectoryResource<IconResource>
     {
         /// <summary>
+        /// Set Language ID
+        /// </summary>
+        public override ushort Language
+        {
+            get => base.Language;
+            set
+            {
+                base.Language = value;
+                foreach (var icon in Icons)
+                {
+                    icon.Language = value;
+                }
+            }
+        }
+
+        /// <summary>
         /// A hardware-independent icon resource.
         /// </summary>
         /// <param name="hModule">Module handle.</param>

--- a/Source/ResourceLib/Resource.cs
+++ b/Source/ResourceLib/Resource.cs
@@ -51,7 +51,7 @@ namespace Vestris.ResourceLib
         /// <summary>
         /// Language ID.
         /// </summary>
-        public UInt16 Language
+        public virtual UInt16 Language
         {
             get
             {


### PR DESCRIPTION
```C#
IconFile iconFile = new IconFile("Icon1.ico");
IconDirectoryResource iconDirectoryResource = new IconDirectoryResource(iconFile);
iconDirectoryResource.Language = ResourceUtil.USENGLISHLANGID;
iconDirectoryResource.SaveTo("test.dll");
```
In fact, the icon resource language ids(multiple size) has not been modified completely