### PR TITLE
Update system.drawing.common nuget package to v4.7.3

### DIFF
--- a/Source/ResourceLib/ResourceLib.csproj
+++ b/Source/ResourceLib/ResourceLib.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Drawing.Common">
-      <Version>4.5.0</Version>
+      <Version>4.7.3</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
There are detected vulnerabilities in v4.5.0 of System.Drawing.Common. I went ahead and updated to the latest safe minor version. 

Would it be possible to have this change be included in the next nuget release so that we can consume these changes over at https://github.com/microsoft/winget-create

Thanks!